### PR TITLE
bug fix for census charts

### DIFF
--- a/frontend/src/app/data-viewer/page.tsx
+++ b/frontend/src/app/data-viewer/page.tsx
@@ -57,6 +57,7 @@ export default function DataViewerPage() {
             ...prev,
             [chart.id]: { data, metadata, tableData },
           })),
+        { name: myLocation.name, year_min: yearMin, year_max: yearMax },
       );
       applyFilters(
         url,
@@ -68,9 +69,10 @@ export default function DataViewerPage() {
             ...prev,
             [chart.id]: { data, metadata, tableData },
           })),
+        { name: comparison.name, year_min: yearMin, year_max: yearMax },
       );
     });
-  }, [myLocation, comparison]);
+  }, [myLocation, comparison, yearMin, yearMax]);
 
   useEffect(() => {
     const seen = new Set<string>();


### PR DESCRIPTION
There was a slight bug with the census charts showing "No data available."

Upon further investigation, the charts expected a "name" parameter (not "filter"). I added a `myLocation.name`, year min, and `year max` arguments. 

Could just have been a problem on my end