### PR TITLE
Use cte filter blocks in zoning sql templates

### DIFF
--- a/backend/query/sql/cdc/county_places.sql
+++ b/backend/query/sql/cdc/county_places.sql
@@ -3,7 +3,7 @@ SELECT
     p.Measure,
     p.Data_Value,
     p.bin,
-    ROUND(p.natl_pct * 100, 2)  AS natl_pct, 
+    ROUND(p.natl_pct * 100, 2) AS natl_pct,
     c.CountyFIPS,
     c.CountyName,
     ST_ASGEOJSON(c.geom) AS geometry

--- a/backend/query/sql/cdc/tract_places.sql
+++ b/backend/query/sql/cdc/tract_places.sql
@@ -3,7 +3,7 @@ SELECT
     p.Measure,
     p.Data_Value,
     p.bin,
-    ROUND(p.natl_pct * 100, 2)  AS natl_pct,
+    ROUND(p.natl_pct * 100, 2) AS natl_pct,
     ST_ASGEOJSON(c.geometry) AS geometry,
     c.name
 FROM cdc_tract_places AS p

--- a/backend/query/sql/zoning/agg_info_table.sql
+++ b/backend/query/sql/zoning/agg_info_table.sql
@@ -1,8 +1,9 @@
+{{ cte_filter_block }}
 SELECT
     i.District_Type AS "District Type",
     SUM(i.Acres) AS Acres,
     ANY_VALUE(c.hex_color) AS hex_color
 FROM zoning_info AS i
 LEFT JOIN zoning_colors AS c ON i.District_Type = c.district_type
-{{ where_string }}
+{{ join_filter_block }}
 GROUP BY i.District_Type

--- a/backend/query/sql/zoning/agg_rules_table.sql
+++ b/backend/query/sql/zoning/agg_rules_table.sql
@@ -1,13 +1,13 @@
+{{ cte_filter_block }}
 SELECT
     r.use_type,
     r.val,
     SUM(i.Acres) AS Acres
-FROM main.zoning_rules AS r
-INNER JOIN main.zoning_info AS i USING (OBJECT_ID)
-
-
-{{ where_string }}
-    AND r.rule = 'Allowance'
+FROM zoning_rules AS r
+INNER JOIN zoning_info AS i USING (OBJECT_ID)
+{{ join_filter_block }}
+WHERE
+    r.rule = 'Allowance'
     AND i.District_Type IN ('Residential', 'Mixed')
 GROUP BY
     r.use_type,

--- a/backend/query/sql/zoning/info_table.sql
+++ b/backend/query/sql/zoning/info_table.sql
@@ -1,3 +1,4 @@
+{{ cte_filter_block }}
 SELECT
     i.County,
     i.Municipal_Name || ' ' || i.District_Name AS "Jurisdiction District Name",
@@ -6,4 +7,4 @@ SELECT
     c.hex_color
 FROM zoning_info AS i
 LEFT JOIN zoning_colors AS c ON i.District_Type = c.district_type
-{{ where_string }}
+{{ join_filter_block }}

--- a/backend/query/sql/zoning/rules.sql
+++ b/backend/query/sql/zoning/rules.sql
@@ -1,9 +1,4 @@
-WITH filtered_rules AS (
-    SELECT DISTINCT OBJECT_ID
-    FROM zoning_rules
-    {{ where_string }}
-)
-
+{{ cte_filter_block }}
 SELECT
     JSON_OBJECT(
         'type', 'FeatureCollection',
@@ -28,6 +23,6 @@ FROM (
         ) AS feature
     FROM zoning_info AS i
     INNER JOIN zoning_geom AS g USING (OBJECT_ID)
-    INNER JOIN filtered_rules USING (OBJECT_ID)
     LEFT JOIN zoning_colors AS c ON i.District_Type = c.district_type
+    {{ join_filter_block }}
 ) AS features

--- a/backend/query/sql/zoning/rules_table.sql
+++ b/backend/query/sql/zoning/rules_table.sql
@@ -1,12 +1,8 @@
-WITH filtered_info AS (
-    SELECT DISTINCT OBJECT_ID FROM zoning_info
-    {{ where_string }}
-)
-
+{{ cte_filter_block }}
 SELECT
     r.OBJECT_ID,
     r.use_type,
     r.rule,
     r.val
 FROM zoning_rules AS r
-INNER JOIN filtered_info USING (OBJECT_ID)
+{{ join_filter_block }}

--- a/backend/tests/test_sql_render.py
+++ b/backend/tests/test_sql_render.py
@@ -61,9 +61,34 @@ QUERY_TEMPLATE_SOURCES = {
         )
     ],
     "query/sql/zoning/agg_info_table.sql": [CTE_SOURCE],
+    "query/sql/zoning/agg_rules_table.sql": [CTE_SOURCE],
     "query/sql/zoning/info_table.sql": [CTE_SOURCE],
     "query/sql/zoning/geo_query.sql": [CTE_SOURCE],
     "query/sql/zoning/rules.sql": [CTE_SOURCE],
+    "query/sql/zoning/rules_table.sql": [CTE_SOURCE],
+    "query/sql/wastewater/service_area_geo_query.sql": [
+        FilterSource(
+            filter_table="service_areas_service_area_info",
+            filters={"County": ["Addison"]},
+            join_key="ID",
+        )
+    ],
+    "query/sql/wastewater/soil_suitability_geo_query.sql": [
+        FilterSource(
+            filter_table="soil_suitability_info_soil_suit",
+            filters={"Suitability": ["Well Suited"]},
+            join_key="ID",
+        )
+    ],
+    "query/sql/wastewater/waste_treatment_geo_query.sql": [
+        FilterSource(
+            filter_table="treatment_facilities_treatment_facility_info",
+            filters={"County": ["Addison"]},
+            join_key="ID",
+        )
+    ],
+    # takes no filter fragments; renders as-is
+    "query/sql/wastewater/waste_treatment_permit_table.sql": [],
 }
 
 # build templates take plain string context instead of FilterSources


### PR DESCRIPTION
Fixes an error in `agg_rules_table.sql` that caused a bare `AND` when no filters were applied because without filters there would be no preceding where clause to AND with.